### PR TITLE
Fix ExampleTransformation

### DIFF
--- a/ExampleAnalysis/CMakeLists.txt
+++ b/ExampleAnalysis/CMakeLists.txt
@@ -65,7 +65,7 @@ target_sources(${EXAMPLEANALYSIS} PRIVATE ${EXAMPLEANALYSIS_MOC})
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
-# Include HDPS headers, including system data plugins
+# Include ManiVault headers, including system data plugins
 target_include_directories(${EXAMPLEANALYSIS} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
@@ -81,7 +81,7 @@ target_link_libraries(${EXAMPLEANALYSIS} PRIVATE Qt6::WebEngineWidgets)
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
-# Link to HDPS and data plugins
+# Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
 # in contrast to having been installed with an installer. In the latter case you'll have
 # to adapt the MV_LINK_PATH and PLUGIN_LINK_PATH to your install folder

--- a/ExampleAnalysis/src/ExampleAnalysisPlugin.cpp
+++ b/ExampleAnalysis/src/ExampleAnalysisPlugin.cpp
@@ -38,7 +38,7 @@ void ExampleAnalysisPlugin::init()
     setOutputDataset(mv::data().createDerivedDataset("Output Data", getInputDataset(), getInputDataset()));
 
     // Retrieve the input dataset for our specific data type (in our case points)
-    // The HDPS core sets the input dataset reference when the plugin is created
+    // The ManiVault core sets the input dataset reference when the plugin is created
     const auto inputPoints  = getInputDataset<Points>();
 
     // Retrieve the output dataset for our specific data type (in our case points)

--- a/ExampleAnalysis/src/ExampleAnalysisPlugin.h
+++ b/ExampleAnalysis/src/ExampleAnalysisPlugin.h
@@ -9,17 +9,17 @@
 #include <QRandomGenerator>
 #include <QtMath>
 
-/** All plugin related classes are in the HDPS plugin namespace */
+/** All plugin related classes are in the ManiVault plugin namespace */
 using namespace mv::plugin;
 
-/** Vector classes used in this plugin are in the HDPS namespace */
+/** Vector classes used in this plugin are in the ManiVault namespace */
 using namespace mv;
 
 /**
  * Example analysis plugin class
  *
  * This analysis plugin class provides skeleton code that shows how to develop 
- * an analysis plugin in HDPS.
+ * an analysis plugin in ManiVault.
  * 
  * The plugin simulates the analysis of points, where point positions are randomly 
  * initialized. During simulation, the points are advanced along a random heading 

--- a/ExampleAnalysis/src/SettingsAction.h
+++ b/ExampleAnalysis/src/SettingsAction.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "actions/Actions.h"
+#include "actions/GroupAction.h"
+#include "actions/DecimalAction.h"
+#include "actions/IntegralAction.h"
+#include "actions/StringAction.h"
+#include "actions/TriggerAction.h"
 
 /** All GUI related classes are in the ManiVault Graphical User Interface namespace */
 using namespace mv::gui;

--- a/ExampleAnalysis/src/SettingsAction.h
+++ b/ExampleAnalysis/src/SettingsAction.h
@@ -2,7 +2,7 @@
 
 #include "actions/Actions.h"
 
-/** All GUI related classes are in the HDPS Graphical User Interface namespace */
+/** All GUI related classes are in the ManiVault Graphical User Interface namespace */
 using namespace mv::gui;
 
 /**
@@ -16,7 +16,7 @@ using namespace mv::gui;
  * actions in a form-like fashion. The order in which they appear corresponds with 
  * the order of declaration.
  *
- * Note: we strongly encourage you to use HDPS core actions to build the user
+ * Note: we strongly encourage you to use ManiVault core actions to build the user
  * interface. Actions separate the data and business logic from the user interface.
  * We have standard actions for editing of strings, decimals, integrals, options,
  * color and color maps. With these components, there is no need to write to create 

--- a/ExampleData/CMakeLists.txt
+++ b/ExampleData/CMakeLists.txt
@@ -63,7 +63,7 @@ target_sources(${EXAMPLEDATA} PRIVATE ${EXAMPLEDATA_MOC})
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
-# Include HDPS headers, including system data plugins
+# Include ManiVault headers, including system data plugins
 target_include_directories(${EXAMPLEDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
@@ -81,7 +81,7 @@ set_target_properties(${EXAMPLEDATA} PROPERTIES PUBLIC_HEADER "${EXAMPLE_DATA_HE
 target_link_libraries(${EXAMPLEDATA} PRIVATE Qt6::Widgets)
 target_link_libraries(${EXAMPLEDATA} PRIVATE Qt6::WebEngineWidgets)
 
-# Link to HDPS and data plugins
+# Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
 # in contrast to having been installed with an installer. In the latter case you'll have
 # to adapt the MV_LINK_PATH and PLUGIN_LINK_PATH to your install folder

--- a/ExampleLoader/CMakeLists.txt
+++ b/ExampleLoader/CMakeLists.txt
@@ -63,7 +63,7 @@ target_sources(${EXAMPLELOADER} PRIVATE ${EXAMPLELOADER_MOC})
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
-# Include HDPS headers, including system data plugins
+# Include ManiVault headers, including system data plugins
 target_include_directories(${EXAMPLELOADER} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ target_compile_features(${EXAMPLELOADER} PRIVATE cxx_std_17)
 target_link_libraries(${EXAMPLELOADER} PRIVATE Qt6::Widgets)
 target_link_libraries(${EXAMPLELOADER} PRIVATE Qt6::WebEngineWidgets)
 
-# Link to HDPS and data plugins
+# Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
 # in contrast to having been installed with an installer. In the latter case you'll have
 # to adapt the MV_LINK_PATH and PLUGIN_LINK_PATH to your install folder

--- a/ExampleTransformation/CMakeLists.txt
+++ b/ExampleTransformation/CMakeLists.txt
@@ -63,7 +63,7 @@ target_sources(${EXAMPLETRANSFORMATION} PRIVATE ${EXAMPLETRANSFORMATION_MOC})
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
-# Include HDPS headers, including system data plugins
+# Include ManiVault headers, including system data plugins
 target_include_directories(${EXAMPLETRANSFORMATION} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ target_compile_features(${EXAMPLETRANSFORMATION} PRIVATE cxx_std_17)
 target_link_libraries(${EXAMPLETRANSFORMATION} PRIVATE Qt6::Widgets)
 target_link_libraries(${EXAMPLETRANSFORMATION} PRIVATE Qt6::WebEngineWidgets)
 
-# Link to HDPS and data plugins
+# Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
 # in contrast to having been installed with an installer. In the latter case you'll have
 # to adapt the MV_LINK_PATH and PLUGIN_LINK_PATH to your install folder

--- a/ExampleTransformation/src/ExampleTransformationPlugin.cpp
+++ b/ExampleTransformation/src/ExampleTransformationPlugin.cpp
@@ -73,7 +73,7 @@ void ExampleTransformationPlugin::transform()
         // Create new data set
         case ExampleTransformationPlugin::Type::Pow2:
         {
-            auto derivedData = _core->createDerivedDataset<Points>(points->getGuiName() + " (Pow2)", points);
+            auto derivedData = mv::data().createDerivedDataset<Points>(points->getGuiName() + " (Pow2)", points);
             events().notifyDatasetAdded(derivedData);
 
             std::vector<float> transformedData;

--- a/ExampleTransformation/src/ExampleTransformationPlugin.cpp
+++ b/ExampleTransformation/src/ExampleTransformationPlugin.cpp
@@ -2,10 +2,8 @@
 
 #include <PointData/PointData.h>
 
-#include <actions/PluginTriggerAction.h>
-
-#include <QtCore>
 #include <QDebug>
+#include <QtCore>
 
 #include <cmath>
 
@@ -28,81 +26,81 @@ ExampleTransformationPlugin::ExampleTransformationPlugin(const PluginFactory* fa
 
 void ExampleTransformationPlugin::transform()
 {
-    for (auto inputDataset : getInputDatasets()) {
-        auto points = Dataset<Points>(inputDataset);
+    auto points = getInputDataset<Points>();
 
-        if (!points.isValid())
-            continue;
+    if (!points.isValid())
+        return;
 
-        // Get reference to dataset task for reporting progress
-        auto& datasetTask = inputDataset->getTask();
+    // Get reference to dataset task for reporting progress
+    auto& datasetTask = points->getTask();
 
-        datasetTask.setName("Transforming");
-        datasetTask.setRunning();
-        datasetTask.setProgressDescription(QString("%1 transformation").arg(getTypeName(_type)));
+    datasetTask.setName("Transforming");
+    datasetTask.setRunning();
+    datasetTask.setProgressDescription(QString("%1 transformation").arg(getTypeName(_type)));
 
-        switch (_type)
+    switch (_type)
+    {
+        // Transform points in place
+        case ExampleTransformationPlugin::Type::Abs:
         {
-            // Transform points in place
-            case ExampleTransformationPlugin::Type::Abs:
-            {
-                points->setLocked(true);
+            points->setLocked(true);
 
-                points->visitData([this, &points, &datasetTask](auto pointData) {
-                    std::uint32_t noPointsProcessed = 0;
+            points->visitData([this, &points, &datasetTask](auto pointData) {
+                std::uint32_t noPointsProcessed = 0;
 
-                    for (auto point : pointData) {
-                        for (std::uint32_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
-                            point[dimensionIndex] = std::abs(point[dimensionIndex]);
-                        }
-
-                        ++noPointsProcessed;
-
-                        if (noPointsProcessed % 1000 == 0) {
-                            datasetTask.setProgress(static_cast<float>(noPointsProcessed) / static_cast<float>(points->getNumPoints()));
-
-                            QApplication::processEvents();
-                        }
+                for (auto point : pointData) {
+                    for (std::uint32_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
+                        point[dimensionIndex] = std::abs(point[dimensionIndex]);
                     }
-                    });
 
-                points->setLocked(false);
+                    ++noPointsProcessed;
 
-                events().notifyDatasetDataChanged(points);
+                    if (noPointsProcessed % 1000 == 0) {
+                        datasetTask.setProgress(static_cast<float>(noPointsProcessed) / static_cast<float>(points->getNumPoints()));
 
-                break;
-            }
-            // Create new data set
-            case ExampleTransformationPlugin::Type::Pow2:
-            {
-                auto derivedData = mv::data().createDerivedDataset<Points>(points->getGuiName() + "(Pow2)", points);
-
-                std::vector<float> transformedData;
-                transformedData.resize(points->getNumPoints() * points->getNumDimensions());
-
-                points->constVisitFromBeginToEnd([&transformedData](auto begin, auto end) {
-                    std::uint32_t noItemsProcessed = 0;
-
-                    for (auto it = begin; it != end; ++it) {
-                        transformedData[noItemsProcessed] = std::pow(*it, 2.0f);
-                        noItemsProcessed++;
+                        QApplication::processEvents();
                     }
-                    });
+                }
+                });
 
+            points.setProperty("Last transformed by", getName());
+            points->setLocked(false);
 
-                derivedData->setData(transformedData.data(), points->getNumPoints(), points->getNumDimensions());
-                events().notifyDatasetDataChanged(derivedData);
+            events().notifyDatasetDataChanged(points);
 
-                break;
-            }
-            default:
-                break;
+            break;
         }
+        // Create new data set
+        case ExampleTransformationPlugin::Type::Pow2:
+        {
+            auto derivedData = _core->createDerivedDataset<Points>(points->getGuiName() + " (Pow2)", points);
+            events().notifyDatasetAdded(derivedData);
 
-        datasetTask.setProgress(1.0f);
-        datasetTask.setFinished();
+            std::vector<float> transformedData;
+            transformedData.resize(points->getNumPoints() * points->getNumDimensions());
 
+            points->constVisitFromBeginToEnd([&transformedData](auto begin, auto end) {
+                std::uint32_t noItemsProcessed = 0;
+
+                for (auto it = begin; it != end; ++it) {
+                    transformedData[noItemsProcessed] = std::pow(*it, 2.0f);
+                    noItemsProcessed++;
+                }
+                });
+
+
+            derivedData->setData(transformedData.data(), points->getNumPoints(), points->getNumDimensions());
+            events().notifyDatasetDataChanged(derivedData);
+
+            break;
+        }
+        default:
+            break;
     }
+
+    datasetTask.setProgress(1.0f);
+    datasetTask.setFinished();
+
 }
 
 
@@ -140,9 +138,9 @@ mv::DataTypes ExampleTransformationPluginFactory::supportedDataTypes() const
     return supportedTypes;
 }
 
-PluginTriggerActions ExampleTransformationPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const
+mv::gui::PluginTriggerActions ExampleTransformationPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const
 {
-    PluginTriggerActions pluginTriggerActions;
+    mv::gui::PluginTriggerActions pluginTriggerActions;
 
     const auto numberOfDatasets = datasets.count();
 
@@ -151,11 +149,11 @@ PluginTriggerActions ExampleTransformationPluginFactory::getPluginTriggerActions
             const auto addPluginTriggerAction = [this, &pluginTriggerActions, datasets](const ExampleTransformationPlugin::Type& type) -> void {
                 const auto typeName = ExampleTransformationPlugin::getTypeName(type);
 
-                auto pluginTriggerAction = new PluginTriggerAction(const_cast<ExampleTransformationPluginFactory*>(this), this, QString("Example/%1").arg(typeName), QString("Perform %1 data transformation").arg(typeName), getIcon(), [this, datasets, type](PluginTriggerAction& pluginTriggerAction) -> void {
-                    for (auto dataset : datasets) {
+                auto pluginTriggerAction = new mv::gui::PluginTriggerAction(const_cast<ExampleTransformationPluginFactory*>(this), this, QString("Example/%1").arg(typeName), QString("Perform %1 data transformation").arg(typeName), getIcon(), [this, datasets, type](mv::gui::PluginTriggerAction& pluginTriggerAction) -> void {
+                    for (const auto& dataset : datasets) {
                         auto pluginInstance = dynamic_cast<ExampleTransformationPlugin*>(plugins().requestPlugin(getKind()));
 
-                        pluginInstance->setInputDatasets(datasets);
+                        pluginInstance->setInputDataset(dataset);
                         pluginInstance->setType(type);
                         pluginInstance->transform();
                     }

--- a/ExampleTransformation/src/ExampleTransformationPlugin.cpp
+++ b/ExampleTransformation/src/ExampleTransformationPlugin.cpp
@@ -74,7 +74,6 @@ void ExampleTransformationPlugin::transform()
         case ExampleTransformationPlugin::Type::Pow2:
         {
             auto derivedData = mv::data().createDerivedDataset<Points>(points->getGuiName() + " (Pow2)", points);
-            events().notifyDatasetAdded(derivedData);
 
             std::vector<float> transformedData;
             transformedData.resize(points->getNumPoints() * points->getNumDimensions());

--- a/ExampleTransformation/src/ExampleTransformationPlugin.h
+++ b/ExampleTransformation/src/ExampleTransformationPlugin.h
@@ -1,17 +1,18 @@
 #pragma once
 
 #include <TransformationPlugin.h>
-#include <actions/StringAction.h>
 
-/** All plugin related classes are in the HDPS plugin namespace */
+#include <QMap>
+#include <QString>
+
+/** All plugin related classes are in the ManiVault plugin namespace */
 using namespace mv::plugin;
-using namespace mv::gui;
 
 /**
  * Example transformation plugin class
  *
  * This transformation plugin class provides skeleton code that shows how to develop 
- * an transformation plugin in HDPS.
+ * an transformation plugin in ManiVault.
  * 
  * In contrast to analysis plugins, transformation do not create an output data set by default,
  * but operate on the input data set. In this example, we provide to transformation options,
@@ -106,6 +107,6 @@ public:
     mv::DataTypes supportedDataTypes() const override;
 
     /** Enable right-click on data set to execute transformation */
-    PluginTriggerActions getPluginTriggerActions(const mv::Datasets& datasets) const override;
+    mv::gui::PluginTriggerActions getPluginTriggerActions(const mv::Datasets& datasets) const override;
 
 };

--- a/ExampleView/CMakeLists.txt
+++ b/ExampleView/CMakeLists.txt
@@ -63,7 +63,7 @@ target_sources(${EXAMPLEVIEW} PRIVATE ${EXAMPLEVIEW_MOC})
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
-# Include HDPS headers, including system data plugins
+# Include ManiVault headers, including system data plugins
 target_include_directories(${EXAMPLEVIEW} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ target_compile_features(${EXAMPLEVIEW} PRIVATE cxx_std_17)
 target_link_libraries(${EXAMPLEVIEW} PRIVATE Qt6::Widgets)
 target_link_libraries(${EXAMPLEVIEW} PRIVATE Qt6::WebEngineWidgets)
 
-# Link to HDPS and data plugins
+# Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
 # in contrast to having been installed with an installer. In the latter case you'll have
 # to adapt the MV_LINK_PATH and PLUGIN_LINK_PATH to your install folder

--- a/ExampleView/src/ExampleViewPlugin.h
+++ b/ExampleView/src/ExampleViewPlugin.h
@@ -9,13 +9,13 @@
 
 #include <QWidget>
 
-/** All plugin related classes are in the HDPS plugin namespace */
+/** All plugin related classes are in the ManiVault plugin namespace */
 using namespace mv::plugin;
 
-/** Drop widget used in this plugin is located in the HDPS gui namespace */
+/** Drop widget used in this plugin is located in the ManiVault gui namespace */
 using namespace mv::gui;
 
-/** Dataset reference used in this plugin is located in the HDPS util namespace */
+/** Dataset reference used in this plugin is located in the ManiVault util namespace */
 using namespace mv::util;
 
 class QLabel;
@@ -24,12 +24,12 @@ class QLabel;
  * Example view plugin class
  *
  * This view plugin class provides skeleton code that shows how to develop
- * a view plugin in HDPS. It shows how to use the built-in drag and drop
+ * a view plugin in ManiVault. It shows how to use the built-in drag and drop
  * behavior.
  *
  * To see the plugin in action, please follow the steps below:
  *
- * 1. Go to the visualization menu in HDPS
+ * 1. Go to the visualization menu in ManiVault
  * 2. Choose the Example view menu item, the view will be added to the layout
  *
  * @authors J. Thijssen & T. Kroes

--- a/ExampleViewJS/CMakeLists.txt
+++ b/ExampleViewJS/CMakeLists.txt
@@ -82,7 +82,7 @@ target_sources(${EXAMPLEVIEWJS} PRIVATE ${EXAMPLEVIEWJS_MOC})
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
-# Include HDPS headers, including system data plugins
+# Include ManiVault headers, including system data plugins
 target_include_directories(${EXAMPLEVIEWJS} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
@@ -98,7 +98,7 @@ target_compile_features(${EXAMPLEVIEWJS} PRIVATE cxx_std_17)
 target_link_libraries(${EXAMPLEVIEWJS} PRIVATE Qt6::Widgets)
 target_link_libraries(${EXAMPLEVIEWJS} PRIVATE Qt6::WebEngineWidgets)
 
-# Link to HDPS and data plugins
+# Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
 # in contrast to having been installed with an installer. In the latter case you'll have
 # to adapt the MV_LINK_PATH and PLUGIN_LINK_PATH to your install folder

--- a/ExampleViewJS/src/ExampleViewJSPlugin.h
+++ b/ExampleViewJS/src/ExampleViewJSPlugin.h
@@ -8,13 +8,13 @@
 
 #include <QWidget>
 
-/** All plugin related classes are in the HDPS plugin namespace */
+/** All plugin related classes are in the ManiVault plugin namespace */
 using namespace mv::plugin;
 
-/** Drop widget used in this plugin is located in the HDPS gui namespace */
+/** Drop widget used in this plugin is located in the ManiVault gui namespace */
 using namespace mv::gui;
 
-/** Dataset reference used in this plugin is located in the HDPS util namespace */
+/** Dataset reference used in this plugin is located in the ManiVault util namespace */
 using namespace mv::util;
 
 class ChartWidget;

--- a/ExampleViewOpenGL/CMakeLists.txt
+++ b/ExampleViewOpenGL/CMakeLists.txt
@@ -75,7 +75,7 @@ target_sources(${EXAMPLEVIEWGL} PRIVATE ${EXAMPLEVIEWGL_MOC})
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
-# Include HDPS headers, including system data plugins
+# Include ManiVault headers, including system data plugins
 target_include_directories(${EXAMPLEVIEWGL} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
@@ -93,7 +93,7 @@ target_link_libraries(${EXAMPLEVIEWGL} PRIVATE Qt6::WebEngineWidgets)
 target_link_libraries(${EXAMPLEVIEWGL} PRIVATE Qt6::OpenGL)
 target_link_libraries(${EXAMPLEVIEWGL} PRIVATE Qt6::OpenGLWidgets)
 
-# Link to HDPS and data plugins
+# Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
 # in contrast to having been installed with an installer. In the latter case you'll have
 # to adapt the MV_LINK_PATH and PLUGIN_LINK_PATH to your install folder

--- a/ExampleViewOpenGL/src/ExampleViewGLPlugin.h
+++ b/ExampleViewOpenGL/src/ExampleViewGLPlugin.h
@@ -9,13 +9,13 @@
 
 #include <QWidget>
 
-/** All plugin related classes are in the HDPS plugin namespace */
+/** All plugin related classes are in the ManiVault plugin namespace */
 using namespace mv::plugin;
 
-/** Drop widget used in this plugin is located in the HDPS gui namespace */
+/** Drop widget used in this plugin is located in the ManiVault gui namespace */
 using namespace mv::gui;
 
-/** Dataset reference used in this plugin is located in the HDPS util namespace */
+/** Dataset reference used in this plugin is located in the ManiVault util namespace */
 using namespace mv::util;
 
 class ExampleGLWidget;

--- a/ExampleWriter/CMakeLists.txt
+++ b/ExampleWriter/CMakeLists.txt
@@ -63,7 +63,7 @@ target_sources(${EXAMPLEWRITER} PRIVATE ${EXAMPLERITER_MOC})
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
-# Include HDPS headers, including system data plugins
+# Include ManiVault headers, including system data plugins
 target_include_directories(${EXAMPLEWRITER} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ target_compile_features(${EXAMPLEWRITER} PRIVATE cxx_std_17)
 target_link_libraries(${EXAMPLEWRITER} PRIVATE Qt6::Widgets)
 target_link_libraries(${EXAMPLEWRITER} PRIVATE Qt6::WebEngineWidgets)
 
-# Link to HDPS and data plugins
+# Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
 # in contrast to having been installed with an installer. In the latter case you'll have
 # to adapt the MV_LINK_PATH and PLUGIN_LINK_PATH to your install folder

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class ExamplePluginsConan(ConanFile):
 
     scm = {
         "type": "git",
-        "subfolder": "ManiVaultStudio/ExamplePlugins",
+        "subfolder": "hdps/ExamplePlugins",
         "url": "auto",
         "revision": "auto",
     }

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,9 +12,9 @@ class ExamplePluginsConan(ConanFile):
     """Class to package ExamplePlugins using conan
 
     Packages both RELEASE and DEBUG.
-    Uses rules_support (github.com/hdps/rulessupport) to derive
+    Uses rules_support (github.com/ManiVaultStudio/rulessupport) to derive
     versioninfo based on the branch naming convention
-    as described in https://github.com/hdps/core/wiki/Branch-naming-rules
+    as described in https://github.com/ManiVaultStudio/core/wiki/Branch-naming-rules
     """
 
     name = "ExamplePlugins"
@@ -22,7 +22,7 @@ class ExamplePluginsConan(ConanFile):
         "A collection of examples including analys, data, loader and view plugins."
     )
     topics = ("hdps", "plugin", "examples", "various")
-    url = "https://github.com/hdps/ExamplePlugins"
+    url = "https://github.com/ManiVaultStudio/ExamplePlugins"
     author = "B. van Lew b.van_lew@lumc.nl"  # conan recipe author
     license = "MIT"
 
@@ -36,7 +36,7 @@ class ExamplePluginsConan(ConanFile):
 
     scm = {
         "type": "git",
-        "subfolder": "hdps/ExamplePlugins",
+        "subfolder": "ManiVaultStudio/ExamplePlugins",
         "url": "auto",
         "revision": "auto",
     }
@@ -115,7 +115,7 @@ class ExamplePluginsConan(ConanFile):
     def build(self):
         print("Build OS is : ", self.settings.os)
 
-        # The ExamplePlugins build expects the HDPS package to be in this install dir
+        # The ExamplePlugins build expects the ManiVaultStudio package to be in this install dir
         hdps_pkg_root = self.deps_cpp_info["hdps-core"].rootpath
         print("Install dir type: ", self.install_dir)
         shutil.copytree(hdps_pkg_root, self.install_dir)


### PR DESCRIPTION
Selecting multiple datasets and then performing a transformation executed the transformation to often.

Also:
- Change most `HDPS` references to `ManiVault`
- Avoid including `actions/Actions.h`