### PR TITLE
Add plugin global settings for ExampleViewOpenGl plugin

### DIFF
--- a/ExampleViewOpenGL/CMakeLists.txt
+++ b/ExampleViewOpenGL/CMakeLists.txt
@@ -57,6 +57,8 @@ set(EXAMPLEVIEWGL_WIDGET
 set(EXAMPLEVIEWGL_ACTIONS
     src/SettingsAction.h
     src/SettingsAction.cpp
+    src/GlobalSettingsAction.h
+    src/GlobalSettingsAction.cpp
 )
 
 source_group( Plugin FILES ${EXAMPLEVIEWGL_SOURCES})

--- a/ExampleViewOpenGL/src/ExampleViewGLPlugin.cpp
+++ b/ExampleViewOpenGL/src/ExampleViewGLPlugin.cpp
@@ -197,7 +197,7 @@ void ExampleViewGLPlugin::createData()
     int numDimensions = 3;
     const std::vector<QString> dimNames {"Dim 1", "Dim 2", "Dim 3"};
 
-    qDebug() << "ExampleViewJSPlugin::createData: Create some example data. " << numPoints << " points, each with " << numDimensions << " dimensions";
+    qDebug() << "ExampleViewGLPlugin::createData: Create some example data. " << numPoints << " points, each with " << numDimensions << " dimensions";
 
     // Create random example data
     std::vector<float> exampleData;

--- a/ExampleViewOpenGL/src/ExampleViewGLPlugin.cpp
+++ b/ExampleViewOpenGL/src/ExampleViewGLPlugin.cpp
@@ -171,7 +171,7 @@ void ExampleViewGLPlugin::loadData(const mv::Datasets& datasets)
     if (datasets.isEmpty())
         return;
 
-    qDebug() << "ExampleViewJSPlugin::loadData: Load data set from ManiVault core";
+    qDebug() << "ExampleViewGLPlugin::loadData: Load data set from ManiVault core";
     _dropWidget->setShowDropIndicator(false);
 
     // Load the first dataset, changes to _currentDataSet are connected with convertDataAndUpdateChart

--- a/ExampleViewOpenGL/src/ExampleViewGLPlugin.cpp
+++ b/ExampleViewOpenGL/src/ExampleViewGLPlugin.cpp
@@ -1,6 +1,8 @@
 #include "ExampleViewGLPlugin.h"
 #include "ExampleGLWidget.h"
 
+#include "GlobalSettingsAction.h"
+
 #include <graphics/Vector2f.h>
 
 #include <DatasetsMimeData.h>
@@ -119,11 +121,12 @@ void ExampleViewGLPlugin::init()
 
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
-    layout->addWidget(_settingsAction.createWidget(&getWidget()));
     layout->addWidget(_exampleGLWidget, 100);
 
     // Apply the layout
     getWidget().setLayout(layout);
+
+    addDockingAction(&_settingsAction);
 
     // Update the data when the scatter plot widget is initialized
     connect(_exampleGLWidget, &ExampleGLWidget::initialized, this, []() { qDebug() << "ExampleGLWidget is initialized."; } );
@@ -225,6 +228,14 @@ void ExampleViewGLPlugin::createData()
 ViewPlugin* ExampleViewGLPluginFactory::produce()
 {
     return new ExampleViewGLPlugin(this);
+}
+
+void ExampleViewGLPluginFactory::initialize()
+{
+    ViewPluginFactory::initialize();
+
+    // Create an instance of our GlobalSettingsAction (derived from PluginGlobalSettingsGroupAction) and assign it to the factory
+    setGlobalSettingsGroupAction(new GlobalSettingsAction(this, this));
 }
 
 QIcon ExampleViewGLPluginFactory::getIcon(const QColor& color /*= Qt::black*/) const

--- a/ExampleViewOpenGL/src/ExampleViewGLPlugin.h
+++ b/ExampleViewOpenGL/src/ExampleViewGLPlugin.h
@@ -68,7 +68,7 @@ protected:
     DropWidget*                 _dropWidget;            /** Widget for drag and drop behavior */
     ExampleGLWidget*            _exampleGLWidget;       /** The OpenGL widget */
     SettingsAction              _settingsAction;        /** Settings action */
-    mv::Dataset<Points>       _currentDataSet;        /** Points smart pointer */
+    mv::Dataset<Points>         _currentDataSet;        /** Points smart pointer */
     std::vector<unsigned int>   _currentDimensions;     /** Stores which dimensions of the current data are shown */
 };
 
@@ -91,7 +91,10 @@ public:
 
     /** Destructor */
     ~ExampleViewGLPluginFactory() override {}
-    
+
+    /** Perform post-construction initialization */
+    void initialize() override;
+
     /** Get plugin icon */
     QIcon getIcon(const QColor& color = Qt::black) const override;
 

--- a/ExampleViewOpenGL/src/GlobalSettingsAction.cpp
+++ b/ExampleViewOpenGL/src/GlobalSettingsAction.cpp
@@ -7,10 +7,13 @@ using namespace mv::gui;
 
 GlobalSettingsAction::GlobalSettingsAction(QObject* parent, const plugin::PluginFactory* pluginFactory) :
     PluginGlobalSettingsGroupAction(parent, pluginFactory),
-    _defaultPointSizeAction(this, "Default point Size", 1, 50, 10)
+    _defaultPointSizeAction(this, "Default point Size", 1, 50, 10),
+    _defaultPointOpacityAction(this, "Default point opacity", 0.f, 1.f, 0.5f)
 {
     _defaultPointSizeAction.setToolTip("Default size of individual points");
+    _defaultPointOpacityAction.setToolTip("Default opacity of individual points");
 
     // The add action automatically assigns a settings prefix to _pointSizeAction so there is no need to do this manually
     addAction(&_defaultPointSizeAction);
+    addAction(&_defaultPointOpacityAction);
 }

--- a/ExampleViewOpenGL/src/GlobalSettingsAction.cpp
+++ b/ExampleViewOpenGL/src/GlobalSettingsAction.cpp
@@ -1,0 +1,16 @@
+#include "GlobalSettingsAction.h"
+
+#include <QHBoxLayout>
+
+using namespace mv;
+using namespace mv::gui;
+
+GlobalSettingsAction::GlobalSettingsAction(QObject* parent, const plugin::PluginFactory* pluginFactory) :
+    PluginGlobalSettingsGroupAction(parent, pluginFactory),
+    _defaultPointSizeAction(this, "Default point Size", 1, 50, 10)
+{
+    _defaultPointSizeAction.setToolTip("Default size of individual points");
+
+    // The add action automatically assigns a settings prefix to _pointSizeAction so there is no need to do this manually
+    addAction(&_defaultPointSizeAction);
+}

--- a/ExampleViewOpenGL/src/GlobalSettingsAction.h
+++ b/ExampleViewOpenGL/src/GlobalSettingsAction.h
@@ -33,7 +33,9 @@ public:
 public: // Action getters
 
     mv::gui::DecimalAction& getDefaultPointSizeAction() { return _defaultPointSizeAction; }
+    mv::gui::DecimalAction& getDefaultPointOpacityAction() { return _defaultPointOpacityAction; }
 
 private:
-    mv::gui::DecimalAction   _defaultPointSizeAction;   /** Default point size action */
+    mv::gui::DecimalAction   _defaultPointSizeAction;       /** Default point size action */
+    mv::gui::DecimalAction   _defaultPointOpacityAction;    /** Default point opacity action */
 };

--- a/ExampleViewOpenGL/src/GlobalSettingsAction.h
+++ b/ExampleViewOpenGL/src/GlobalSettingsAction.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <PluginGlobalSettingsGroupAction.h>
+
+#include <actions/DecimalAction.h>
+
+namespace mv {
+    namespace plugin {
+        class PluginFactory;
+    }
+}
+
+/**
+ * Global settings action class
+ *
+ * Action class for configuring global settings
+ * 
+ * This group action (once assigned to the plugin factory, see ExampleViewGLPluginFactory::initialize()) is 
+ * added to the global settings panel, accessible through the file > settings menu.
+ * 
+ */
+class GlobalSettingsAction : public mv::gui::PluginGlobalSettingsGroupAction
+{
+public:
+
+    /**
+     * Construct with pointer to \p parent object and \p pluginFactory
+     * @param parent Pointer to parent object
+     * @param pluginFactory Pointer to plugin factory
+     */
+    Q_INVOKABLE GlobalSettingsAction(QObject* parent, const mv::plugin::PluginFactory* pluginFactory);
+
+public: // Action getters
+
+    mv::gui::DecimalAction& getDefaultPointSizeAction() { return _defaultPointSizeAction; }
+
+private:
+    mv::gui::DecimalAction   _defaultPointSizeAction;   /** Default point size action */
+};

--- a/ExampleViewOpenGL/src/SettingsAction.cpp
+++ b/ExampleViewOpenGL/src/SettingsAction.cpp
@@ -35,6 +35,7 @@ SettingsAction::SettingsAction(QObject* parent, const QString& title) :
     _datasetNameAction.setString(" (No data loaded yet)");
 
     _pointSizeAction.setValue(mv::settings().getPluginGlobalSettingsGroupAction<GlobalSettingsAction>(_exampleViewGLPlugin)->getDefaultPointSizeAction().getValue());
+    _pointOpacityAction.setValue(mv::settings().getPluginGlobalSettingsGroupAction<GlobalSettingsAction>(_exampleViewGLPlugin)->getDefaultPointOpacityAction().getValue());
 
     connect(&_xDimensionPickerAction, &DimensionPickerAction::currentDimensionIndexChanged, _exampleViewGLPlugin, &ExampleViewGLPlugin::updatePlot);
     connect(&_yDimensionPickerAction, &DimensionPickerAction::currentDimensionIndexChanged, _exampleViewGLPlugin, &ExampleViewGLPlugin::updatePlot);

--- a/ExampleViewOpenGL/src/SettingsAction.cpp
+++ b/ExampleViewOpenGL/src/SettingsAction.cpp
@@ -1,4 +1,5 @@
 #include "SettingsAction.h"
+#include "GlobalSettingsAction.h"
 
 #include "ExampleViewGLPlugin.h"
 
@@ -7,7 +8,7 @@
 using namespace mv::gui;
 
 SettingsAction::SettingsAction(QObject* parent, const QString& title) :
-    WidgetAction(parent, title),
+    GroupAction(parent, title),
     _exampleViewGLPlugin(dynamic_cast<ExampleViewGLPlugin*>(parent)),
     _datasetNameAction(this, "Dataset Name"),
     _xDimensionPickerAction(this, "X"),
@@ -16,6 +17,12 @@ SettingsAction::SettingsAction(QObject* parent, const QString& title) :
     _pointOpacityAction(this, "Opacity", 0.f, 1.f, 0.75f, 2)
 {
     setText("Settings");
+
+    addAction(&_datasetNameAction);
+    addAction(&_xDimensionPickerAction);
+    addAction(&_yDimensionPickerAction);
+    addAction(&_pointSizeAction);
+    addAction(&_pointOpacityAction);
 
     _datasetNameAction.setToolTip("Name of currently shown dataset");
     _xDimensionPickerAction.setToolTip("X dimension");
@@ -27,50 +34,11 @@ SettingsAction::SettingsAction(QObject* parent, const QString& title) :
     _datasetNameAction.setText("Dataset name");
     _datasetNameAction.setString(" (No data loaded yet)");
 
-    connect(&_xDimensionPickerAction, &DimensionPickerAction::currentDimensionIndexChanged, [this](const std::uint32_t& currentDimensionIndex) {
-        _exampleViewGLPlugin->updatePlot();
-    });
+    _pointSizeAction.setValue(mv::settings().getPluginGlobalSettingsGroupAction<GlobalSettingsAction>(_exampleViewGLPlugin)->getDefaultPointSizeAction().getValue());
 
-    connect(&_yDimensionPickerAction, &DimensionPickerAction::currentDimensionIndexChanged, [this](const std::uint32_t& currentDimensionIndex) {
-        _exampleViewGLPlugin->updatePlot();
-    });
+    connect(&_xDimensionPickerAction, &DimensionPickerAction::currentDimensionIndexChanged, _exampleViewGLPlugin, &ExampleViewGLPlugin::updatePlot);
+    connect(&_yDimensionPickerAction, &DimensionPickerAction::currentDimensionIndexChanged, _exampleViewGLPlugin, &ExampleViewGLPlugin::updatePlot);
+    connect(&_pointSizeAction, &DecimalAction::valueChanged, _exampleViewGLPlugin, &ExampleViewGLPlugin::updatePlot);
+    connect(&_pointOpacityAction, &DecimalAction::valueChanged, _exampleViewGLPlugin, &ExampleViewGLPlugin::updatePlot);
 
-    connect(&_pointSizeAction, &DecimalAction::valueChanged, [this](float val) {
-        _exampleViewGLPlugin->updatePlot();
-    });
-
-    connect(&_pointOpacityAction, &DecimalAction::valueChanged, [this](float val) {
-        _exampleViewGLPlugin->updatePlot();
-    });
-
-}
-
-SettingsAction::Widget::Widget(QWidget* parent, SettingsAction* settingsAction) :
-    WidgetActionWidget(parent, settingsAction)
-{
-    setAutoFillBackground(true);
-    setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
-
-    auto layout = new QHBoxLayout();
-
-    const int margin = 5;
-    layout->setContentsMargins(margin, margin, margin, margin);
-    layout->setSpacing(2);
-
-    layout->addWidget(settingsAction->getDatasetNameAction().createLabelWidget(this));
-    layout->addWidget(settingsAction->getDatasetNameAction().createWidget(this));
-
-    layout->addWidget(settingsAction->getXDimensionPickerAction().createLabelWidget(this));
-    layout->addWidget(settingsAction->getXDimensionPickerAction().createWidget(this));
-
-    layout->addWidget(settingsAction->getYDimensionPickerAction().createLabelWidget(this));
-    layout->addWidget(settingsAction->getYDimensionPickerAction().createWidget(this));
-
-    layout->addWidget(settingsAction->getPointSizeAction().createLabelWidget(this));
-    layout->addWidget(settingsAction->getPointSizeAction().createWidget(this));
-
-    layout->addWidget(settingsAction->getPointOpacityAction().createLabelWidget(this));
-    layout->addWidget(settingsAction->getPointOpacityAction().createWidget(this));
-
-    setLayout(layout);
 }

--- a/ExampleViewOpenGL/src/SettingsAction.h
+++ b/ExampleViewOpenGL/src/SettingsAction.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <actions/WidgetAction.h>
+#include <actions/GroupAction.h>
 #include <actions/StringAction.h>
 #include <actions/DecimalAction.h>
 #include <PointData/DimensionPickerAction.h>
@@ -8,14 +8,16 @@
 using namespace mv::gui;
 
 class ExampleViewGLPlugin;
+
 /**
  * Settings action class
  *
  * Action class for configuring settings
  */
-class SettingsAction : public WidgetAction
+class SettingsAction : public GroupAction
 {
 public:
+
     /**
      * Construct with \p parent object and \p title
      * @param parent Pointer to parent object
@@ -30,17 +32,6 @@ public: // Action getters
     DimensionPickerAction& getYDimensionPickerAction() { return _yDimensionPickerAction; }
     DecimalAction& getPointSizeAction() { return _pointSizeAction; }
     DecimalAction& getPointOpacityAction() { return _pointOpacityAction; }
-
-protected:
-
-    class Widget : public WidgetActionWidget {
-    public:
-        Widget(QWidget* parent, SettingsAction* settingsAction);
-    };
-
-    QWidget* getWidget(QWidget* parent, const std::int32_t& widgetFlags) override {
-        return new SettingsAction::Widget(parent, this);
-    };
 
 private:
     ExampleViewGLPlugin*    _exampleViewGLPlugin;       /** Pointer to Example OpenGL Viewer Plugin */


### PR DESCRIPTION
This PR adds new features and addresses some issues:
* Adds two global plugin settings to the ExampleViewOpenGl:
  * Default point size
  * Default point opacity
* Simplifies the `SettingsAction` by deriving from `GroupAction`, thereby eliminating the need to create a widget manually
* Fixes some small copy-paste typos
