### PR TITLE
Clean up CMake files

### DIFF
--- a/ExampleAnalysis/CMakeLists.txt
+++ b/ExampleAnalysis/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 # -----------------------------------------------------------------------------
 # ExampleAnalysis Plugin
 # -----------------------------------------------------------------------------
-set(EXAMPLEANALYSIS "ExampleAnalysisPlugin")
-PROJECT(${EXAMPLEANALYSIS})
+PROJECT("ExampleAnalysisPlugin")
 
 # -----------------------------------------------------------------------------
 # CMake Options
@@ -15,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
 # -----------------------------------------------------------------------------
@@ -39,7 +38,7 @@ find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(EXAMPLEANALYSIS_SOURCES
+set(PLUGIN_SOURCES
     src/ExampleAnalysisPlugin.h
     src/ExampleAnalysisPlugin.cpp
     src/SettingsAction.h
@@ -48,35 +47,35 @@ set(EXAMPLEANALYSIS_SOURCES
 )
 
 set(PLUGIN_MOC_HEADERS
-	src/ExampleAnalysisPlugin.h
+    src/ExampleAnalysisPlugin.h
 )
 
-source_group( Plugin FILES ${EXAMPLEANALYSIS_SOURCES})
+source_group( Plugin FILES ${PLUGIN_SOURCES})
 
 # -----------------------------------------------------------------------------
 # CMake Target
 # -----------------------------------------------------------------------------
 # Create dynamic library for the plugin
-add_library(${EXAMPLEANALYSIS} SHARED ${EXAMPLEANALYSIS_SOURCES})
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_SOURCES})
 
-qt_wrap_cpp(EXAMPLEANALYSIS_MOC ${PLUGIN_MOC_HEADERS} TARGET ${EXAMPLEANALYSIS})
-target_sources(${EXAMPLEANALYSIS} PRIVATE ${EXAMPLEANALYSIS_MOC})
+qt_wrap_cpp(PLUGIN_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${PLUGIN_MOC})
 
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
 # Include ManiVault headers, including system data plugins
-target_include_directories(${EXAMPLEANALYSIS} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
+target_include_directories(${PROJECT_NAME} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
 # Target properties
 # -----------------------------------------------------------------------------
 # Request C++17
-target_compile_features(${EXAMPLEANALYSIS} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # Link to Qt libraries
-target_link_libraries(${EXAMPLEANALYSIS} PRIVATE Qt6::Widgets)
-target_link_libraries(${EXAMPLEANALYSIS} PRIVATE Qt6::WebEngineWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::WebEngineWidgets)
 
 # -----------------------------------------------------------------------------
 # Target library linking
@@ -92,19 +91,19 @@ set(MV_LINK_SUFFIX $<IF:$<CXX_COMPILER_ID:MSVC>,${CMAKE_LINK_LIBRARY_SUFFIX},${C
 set(MV_LINK_LIBRARY "${MV_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}MV_Public${MV_LINK_SUFFIX}")
 set(POINTDATA_LINK_LIBRARY "${PLUGIN_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${MV_LINK_SUFFIX}") 
 
-target_link_libraries(${EXAMPLEANALYSIS} PRIVATE "${MV_LINK_LIBRARY}")
-target_link_libraries(${EXAMPLEANALYSIS} PRIVATE "${POINTDATA_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${MV_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 
 # -----------------------------------------------------------------------------
 # Target installation
 # -----------------------------------------------------------------------------
 # Install the shared plugin libary to the "Plugins" folder in the ManiVault install directory
-install(TARGETS ${EXAMPLEANALYSIS}
+install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
 )
 
-add_custom_command(TARGET ${EXAMPLEANALYSIS} POST_BUILD
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
@@ -116,6 +115,6 @@ add_custom_command(TARGET ${EXAMPLEANALYSIS} POST_BUILD
 # -----------------------------------------------------------------------------
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
-    set_property(TARGET ${EXAMPLEANALYSIS} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
-    set_property(TARGET ${EXAMPLEANALYSIS} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${MV_INSTALL_DIR}/debug/ManiVault Studio.exe","${MV_INSTALL_DIR}/release/ManiVault Studio.exe">)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/ManiVault\ Studio.exe,${MV_INSTALL_DIR}/release/ManiVault\ Studio.exe>)
 endif()

--- a/ExampleData/CMakeLists.txt
+++ b/ExampleData/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 # -----------------------------------------------------------------------------
 # ExampleData Plugin
 # -----------------------------------------------------------------------------
-set(EXAMPLEDATA "ExampleDataPlugin")
-PROJECT(${EXAMPLEDATA})
+PROJECT("ExampleDataPlugin")
 
 # -----------------------------------------------------------------------------
 # CMake Options and Setup
@@ -15,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
 # Include cmake tools
@@ -42,54 +41,54 @@ find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(EXAMPLEDATA_SOURCES
+set(PLUGIN_SOURCES
     src/ExampleDataPlugin.h
     src/ExampleDataPlugin.cpp
     src/ExampleDataPlugin.json
 )
 
-set(EXAMPLE_DATA_HEADERS
+set(PLUGIN_HEADERS
     src/ExampleDataPlugin.h
 )
 
-source_group( Plugin FILES ${EXAMPLEDATA_SOURCES})
+source_group( Plugin FILES ${PLUGIN_SOURCES})
 
 # -----------------------------------------------------------------------------
 # CMake Target
 # -----------------------------------------------------------------------------
 # Create dynamic library for the plugin
-add_library(${EXAMPLEDATA} SHARED ${EXAMPLEDATA_SOURCES})
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_SOURCES})
 
-target_sources(${EXAMPLEDATA} PRIVATE 
-    ${EXAMPLEDATA_SOURCES}
+target_sources(${PROJECT_NAME} PRIVATE 
+    ${PLUGIN_SOURCES}
 )
 
 # Generate a header file that contains the EXPORT macro for this library.
-generate_export_header(${EXAMPLEDATA} EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/${EXAMPLEDATA}_export.h)
+generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h)
 
 # Add the generated header to the plugin's header files
-list(APPEND EXAMPLE_DATA_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/${EXAMPLEDATA}_export.h)
+list(APPEND PLUGIN_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_export.h)
 
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
 # Include ManiVault headers, including system data plugins
-target_include_directories(${EXAMPLEDATA} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
+target_include_directories(${PROJECT_NAME} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
 # Target properties
 # -----------------------------------------------------------------------------
 # Request C++17
-target_compile_features(${EXAMPLEDATA} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
-set_target_properties(${EXAMPLEDATA} PROPERTIES PUBLIC_HEADER "${EXAMPLE_DATA_HEADERS}")
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${PLUGIN_HEADERS}")
 
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
 # Link to Qt libraries
-target_link_libraries(${EXAMPLEDATA} PRIVATE Qt6::Widgets)
-target_link_libraries(${EXAMPLEDATA} PRIVATE Qt6::WebEngineWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::WebEngineWidgets)
 
 # Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
@@ -102,8 +101,8 @@ set(MV_LINK_SUFFIX $<IF:$<CXX_COMPILER_ID:MSVC>,${CMAKE_LINK_LIBRARY_SUFFIX},${C
 set(MV_LINK_LIBRARY "${MV_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}MV_Public${MV_LINK_SUFFIX}")
 set(POINTDATA_LINK_LIBRARY "${PLUGIN_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${MV_LINK_SUFFIX}") 
 
-target_link_libraries(${EXAMPLEDATA} PRIVATE "${MV_LINK_LIBRARY}")
-target_link_libraries(${EXAMPLEDATA} PRIVATE "${POINTDATA_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${MV_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 
 # -----------------------------------------------------------------------------
 # Target installation
@@ -112,14 +111,14 @@ target_link_libraries(${EXAMPLEDATA} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 # (as well as the dynamic link library on Windows) 
 # in addition to the dynamic plugins libraries so that other plugins can link against this new data type
 # more info: https://cmake.org/cmake/help/book/mastering-cmake/chapter/Install.html
-install(TARGETS ${EXAMPLEDATA}
+install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
     ARCHIVE DESTINATION lib     COMPONENT LINKLIB # Windows .lib
-    PUBLIC_HEADER DESTINATION include/${EXAMPLEDATA} COMPONENT HEADERS
+    PUBLIC_HEADER DESTINATION include/${PROJECT_NAME} COMPONENT HEADERS
 )
 
-add_custom_command(TARGET ${EXAMPLEDATA} POST_BUILD
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
@@ -131,6 +130,6 @@ add_custom_command(TARGET ${EXAMPLEDATA} POST_BUILD
 # -----------------------------------------------------------------------------
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
-    set_property(TARGET ${EXAMPLEDATA} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
-    set_property(TARGET ${EXAMPLEDATA} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${MV_INSTALL_DIR}/debug/ManiVault Studio.exe","${MV_INSTALL_DIR}/release/ManiVault Studio.exe">)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/ManiVault\ Studio.exe,${MV_INSTALL_DIR}/release/ManiVault\ Studio.exe>)
 endif()

--- a/ExampleLoader/CMakeLists.txt
+++ b/ExampleLoader/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 # -----------------------------------------------------------------------------
 # ExampleLoader Plugin
 # -----------------------------------------------------------------------------
-set(EXAMPLELOADER "ExampleLoaderPlugin")
-PROJECT(${EXAMPLELOADER})
+PROJECT("ExampleLoaderPlugin")
 
 # -----------------------------------------------------------------------------
 # CMake Options
@@ -15,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
 # -----------------------------------------------------------------------------
@@ -39,45 +38,45 @@ find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(EXAMPLELOADER_SOURCES
+set(PLUGIN_SOURCES
     src/ExampleLoaderPlugin.h
     src/ExampleLoaderPlugin.cpp
     src/ExampleLoaderPlugin.json
 )
 
 set(PLUGIN_MOC_HEADERS
-	src/ExampleLoaderPlugin.h
+    src/ExampleLoaderPlugin.h
 )
 
-source_group( Plugin FILES ${EXAMPLELOADER_SOURCES})
+source_group( Plugin FILES ${PLUGIN_SOURCES})
 
 # -----------------------------------------------------------------------------
 # CMake Target
 # -----------------------------------------------------------------------------
 # Create dynamic library for the plugin
-add_library(${EXAMPLELOADER} SHARED ${EXAMPLELOADER_SOURCES})
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_SOURCES})
 
-qt_wrap_cpp(EXAMPLELOADER_MOC ${PLUGIN_MOC_HEADERS} TARGET ${EXAMPLELOADER})
-target_sources(${EXAMPLELOADER} PRIVATE ${EXAMPLELOADER_MOC})
+qt_wrap_cpp(PLUGIN_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${PLUGIN_MOC})
 
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
 # Include ManiVault headers, including system data plugins
-target_include_directories(${EXAMPLELOADER} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
+target_include_directories(${PROJECT_NAME} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
 # Target properties
 # -----------------------------------------------------------------------------
 # Request C++17
-target_compile_features(${EXAMPLELOADER} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
 # Link to Qt libraries
-target_link_libraries(${EXAMPLELOADER} PRIVATE Qt6::Widgets)
-target_link_libraries(${EXAMPLELOADER} PRIVATE Qt6::WebEngineWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::WebEngineWidgets)
 
 # Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
@@ -90,19 +89,19 @@ set(MV_LINK_SUFFIX $<IF:$<CXX_COMPILER_ID:MSVC>,${CMAKE_LINK_LIBRARY_SUFFIX},${C
 set(MV_LINK_LIBRARY "${MV_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}MV_Public${MV_LINK_SUFFIX}")
 set(POINTDATA_LINK_LIBRARY "${PLUGIN_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${MV_LINK_SUFFIX}") 
 
-target_link_libraries(${EXAMPLELOADER} PRIVATE "${MV_LINK_LIBRARY}")
-target_link_libraries(${EXAMPLELOADER} PRIVATE "${POINTDATA_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${MV_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 
 # -----------------------------------------------------------------------------
 # Target installation
 # -----------------------------------------------------------------------------
 # Install the shared plugin libary to the "Plugins" folder in the ManiVault install directory
-install(TARGETS ${EXAMPLELOADER}
+install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
 )
 
-add_custom_command(TARGET ${EXAMPLELOADER} POST_BUILD
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
@@ -115,6 +114,6 @@ add_custom_command(TARGET ${EXAMPLELOADER} POST_BUILD
 # Automatically set the debug environment (command + working directory) for MSVC
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
-    set_property(TARGET ${EXAMPLELOADER} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
-    set_property(TARGET ${EXAMPLELOADER} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${MV_INSTALL_DIR}/debug/ManiVault Studio.exe","${MV_INSTALL_DIR}/release/ManiVault Studio.exe">)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/ManiVault\ Studio.exe,${MV_INSTALL_DIR}/release/ManiVault\ Studio.exe>)
 endif()

--- a/ExampleTransformation/CMakeLists.txt
+++ b/ExampleTransformation/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 # -----------------------------------------------------------------------------
 # ExampleTransformation Plugin
 # -----------------------------------------------------------------------------
-set(EXAMPLETRANSFORMATION "ExampleTransformationPlugin")
-PROJECT(${EXAMPLETRANSFORMATION})
+PROJECT("ExampleTransformationPlugin")
 
 # -----------------------------------------------------------------------------
 # CMake Options
@@ -15,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
 # -----------------------------------------------------------------------------
@@ -39,45 +38,45 @@ find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(EXAMPLETRANSFORMATION_SOURCES
+set(PLUGIN_SOURCES
     src/ExampleTransformationPlugin.h
     src/ExampleTransformationPlugin.cpp
     src/ExampleTransformationPlugin.json
 )
 
 set(PLUGIN_MOC_HEADERS
-	src/ExampleTransformationPlugin.h
+    src/ExampleTransformationPlugin.h
 )
 
-source_group( Plugin FILES ${EXAMPLETRANSFORMATION_SOURCES})
+source_group( Plugin FILES ${PLUGIN_SOURCES})
 
 # -----------------------------------------------------------------------------
 # CMake Target
 # -----------------------------------------------------------------------------
 # Create dynamic library for the plugin
-add_library(${EXAMPLETRANSFORMATION} SHARED ${EXAMPLETRANSFORMATION_SOURCES})
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_SOURCES})
 
-qt_wrap_cpp(EXAMPLETRANSFORMATION_MOC ${PLUGIN_MOC_HEADERS} TARGET ${EXAMPLETRANSFORMATION})
-target_sources(${EXAMPLETRANSFORMATION} PRIVATE ${EXAMPLETRANSFORMATION_MOC})
+qt_wrap_cpp(PLUGIN_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${PLUGIN_MOC})
 
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
 # Include ManiVault headers, including system data plugins
-target_include_directories(${EXAMPLETRANSFORMATION} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
+target_include_directories(${PROJECT_NAME} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
 # Target properties
 # -----------------------------------------------------------------------------
 # Request C++17
-target_compile_features(${EXAMPLETRANSFORMATION} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
 # Link to Qt libraries
-target_link_libraries(${EXAMPLETRANSFORMATION} PRIVATE Qt6::Widgets)
-target_link_libraries(${EXAMPLETRANSFORMATION} PRIVATE Qt6::WebEngineWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::WebEngineWidgets)
 
 # Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
@@ -90,19 +89,19 @@ set(MV_LINK_SUFFIX $<IF:$<CXX_COMPILER_ID:MSVC>,${CMAKE_LINK_LIBRARY_SUFFIX},${C
 set(MV_LINK_LIBRARY "${MV_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}MV_Public${MV_LINK_SUFFIX}")
 set(POINTDATA_LINK_LIBRARY "${PLUGIN_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${MV_LINK_SUFFIX}") 
 
-target_link_libraries(${EXAMPLETRANSFORMATION} PRIVATE "${MV_LINK_LIBRARY}")
-target_link_libraries(${EXAMPLETRANSFORMATION} PRIVATE "${POINTDATA_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${MV_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 
 # -----------------------------------------------------------------------------
 # Target installation
 # -----------------------------------------------------------------------------
 # Install the shared plugin libary to the "Plugins" folder in the ManiVault install directory
-install(TARGETS ${EXAMPLETRANSFORMATION}
+install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
 )
 
-add_custom_command(TARGET ${EXAMPLETRANSFORMATION} POST_BUILD
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
@@ -115,5 +114,5 @@ add_custom_command(TARGET ${EXAMPLETRANSFORMATION} POST_BUILD
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
     set_property(TARGET ${EXAMPLETRANSFORMATION} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
-    set_property(TARGET ${EXAMPLETRANSFORMATION} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${MV_INSTALL_DIR}/debug/ManiVault Studio.exe","${MV_INSTALL_DIR}/release/ManiVault Studio.exe">)
+    set_property(TARGET ${EXAMPLETRANSFORMATION} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/ManiVault\ Studio.exe,${MV_INSTALL_DIR}/release/ManiVault\ Studio.exe>)
 endif()

--- a/ExampleView/CMakeLists.txt
+++ b/ExampleView/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 # -----------------------------------------------------------------------------
 # ExampleView Plugin
 # -----------------------------------------------------------------------------
-set(EXAMPLEVIEW "ExampleViewPlugin")
-PROJECT(${EXAMPLEVIEW})
+PROJECT("ExampleViewPlugin")
 
 # -----------------------------------------------------------------------------
 # CMake Options
@@ -15,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
 # -----------------------------------------------------------------------------
@@ -39,45 +38,45 @@ find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(EXAMPLEVIEW_SOURCES
+set(PLUGIN_SOURCES
     src/ExampleViewPlugin.h
     src/ExampleViewPlugin.cpp
     src/ExampleViewPlugin.json
 )
 
 set(PLUGIN_MOC_HEADERS
-	src/ExampleViewPlugin.h
+    src/ExampleViewPlugin.h
 )
 
-source_group( Plugin FILES ${EXAMPLEVIEW_SOURCES})
+source_group( Plugin FILES ${PLUGIN_SOURCES})
 
 # -----------------------------------------------------------------------------
 # CMake Target
 # -----------------------------------------------------------------------------
 # Create dynamic library for the plugin
-add_library(${EXAMPLEVIEW} SHARED ${EXAMPLEVIEW_SOURCES})
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_SOURCES})
 
-qt_wrap_cpp(EXAMPLEVIEW_MOC ${PLUGIN_MOC_HEADERS} TARGET ${EXAMPLEVIEW})
-target_sources(${EXAMPLEVIEW} PRIVATE ${EXAMPLEVIEW_MOC})
+qt_wrap_cpp(PLUGIN_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${PLUGIN_MOC})
 
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
 # Include ManiVault headers, including system data plugins
-target_include_directories(${EXAMPLEVIEW} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
+target_include_directories(${PROJECT_NAME} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
 # Target properties
 # -----------------------------------------------------------------------------
 # Request C++17
-target_compile_features(${EXAMPLEVIEW} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
 # Link to Qt libraries
-target_link_libraries(${EXAMPLEVIEW} PRIVATE Qt6::Widgets)
-target_link_libraries(${EXAMPLEVIEW} PRIVATE Qt6::WebEngineWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::WebEngineWidgets)
 
 # Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
@@ -90,19 +89,19 @@ set(MV_LINK_SUFFIX $<IF:$<CXX_COMPILER_ID:MSVC>,${CMAKE_LINK_LIBRARY_SUFFIX},${C
 set(MV_LINK_LIBRARY "${MV_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}MV_Public${MV_LINK_SUFFIX}")
 set(POINTDATA_LINK_LIBRARY "${PLUGIN_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${MV_LINK_SUFFIX}") 
 
-target_link_libraries(${EXAMPLEVIEW} PRIVATE "${MV_LINK_LIBRARY}")
-target_link_libraries(${EXAMPLEVIEW} PRIVATE "${POINTDATA_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${MV_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 
 # -----------------------------------------------------------------------------
 # Target installation
 # -----------------------------------------------------------------------------
 # Install the shared plugin libary to the "Plugins" folder in the ManiVault install directory
-install(TARGETS ${EXAMPLEVIEW}
+install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
 )
 
-add_custom_command(TARGET ${EXAMPLEVIEW} POST_BUILD
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
@@ -114,6 +113,6 @@ add_custom_command(TARGET ${EXAMPLEVIEW} POST_BUILD
 # -----------------------------------------------------------------------------
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
-    set_property(TARGET ${EXAMPLEVIEW} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
-    set_property(TARGET ${EXAMPLEVIEW} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${MV_INSTALL_DIR}/debug/ManiVault Studio.exe","${MV_INSTALL_DIR}/release/ManiVault Studio.exe">)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/ManiVault\ Studio.exe,${MV_INSTALL_DIR}/release/ManiVault\ Studio.exe>)
 endif()

--- a/ExampleViewJS/CMakeLists.txt
+++ b/ExampleViewJS/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 # -----------------------------------------------------------------------------
 # ExampleViewJS Plugin
 # -----------------------------------------------------------------------------
-set(EXAMPLEVIEWJS "ExampleViewJSPlugin")
-PROJECT(${EXAMPLEVIEWJS})
+PROJECT("ExampleViewJSPlugin")
 
 # -----------------------------------------------------------------------------
 # CMake Options
@@ -15,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
 # -----------------------------------------------------------------------------
@@ -39,7 +38,7 @@ find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(EXAMPLEVIEWJS_SOURCES
+set(PLUGIN_SOURCES
     src/ExampleViewJSPlugin.h
     src/ExampleViewJSPlugin.cpp
     src/ChartWidget.h
@@ -48,7 +47,7 @@ set(EXAMPLEVIEWJS_SOURCES
 )
 
 set(PLUGIN_MOC_HEADERS
-	src/ExampleViewJSPlugin.h
+    src/ExampleViewJSPlugin.h
 )
 
 set(WEB
@@ -66,7 +65,7 @@ set(AUX
 
 qt6_add_resources(RESOURCE_FILES res/example_chart.qrc)
 
-source_group( Plugin FILES ${EXAMPLEVIEWJS_SOURCES})
+source_group( Plugin FILES ${PLUGIN_SOURCES})
 source_group( Web FILES ${WEB})
 source_group( Aux FILES ${AUX})
 
@@ -74,29 +73,29 @@ source_group( Aux FILES ${AUX})
 # CMake Target
 # -----------------------------------------------------------------------------
 # Create dynamic library for the plugin
-add_library(${EXAMPLEVIEWJS} SHARED ${EXAMPLEVIEWJS_SOURCES} ${AUX} ${WEB} ${RESOURCE_FILES})
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_SOURCES} ${AUX} ${WEB} ${RESOURCE_FILES})
 
-qt_wrap_cpp(EXAMPLEVIEWJS_MOC ${PLUGIN_MOC_HEADERS} TARGET ${EXAMPLEVIEWJS})
-target_sources(${EXAMPLEVIEWJS} PRIVATE ${EXAMPLEVIEWJS_MOC})
+qt_wrap_cpp(PLUGIN_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${PLUGIN_MOC})
 
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
 # Include ManiVault headers, including system data plugins
-target_include_directories(${EXAMPLEVIEWJS} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
+target_include_directories(${PROJECT_NAME} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
 # Target properties
 # -----------------------------------------------------------------------------
 # Request C++17
-target_compile_features(${EXAMPLEVIEWJS} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
 # Link to Qt libraries
-target_link_libraries(${EXAMPLEVIEWJS} PRIVATE Qt6::Widgets)
-target_link_libraries(${EXAMPLEVIEWJS} PRIVATE Qt6::WebEngineWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::WebEngineWidgets)
 
 # Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
@@ -109,19 +108,19 @@ set(MV_LINK_SUFFIX $<IF:$<CXX_COMPILER_ID:MSVC>,${CMAKE_LINK_LIBRARY_SUFFIX},${C
 set(MV_LINK_LIBRARY "${MV_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}MV_Public${MV_LINK_SUFFIX}")
 set(POINTDATA_LINK_LIBRARY "${PLUGIN_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${MV_LINK_SUFFIX}") 
 
-target_link_libraries(${EXAMPLEVIEWJS} PRIVATE "${MV_LINK_LIBRARY}")
-target_link_libraries(${EXAMPLEVIEWJS} PRIVATE "${POINTDATA_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${MV_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 
 # -----------------------------------------------------------------------------
 # Target installation
 # -----------------------------------------------------------------------------
 # Install the shared plugin libary to the "Plugins" folder in the ManiVault install directory
-install(TARGETS ${EXAMPLEVIEWJS}
+install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
 )
 
-add_custom_command(TARGET ${EXAMPLEVIEWJS} POST_BUILD
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
@@ -133,6 +132,6 @@ add_custom_command(TARGET ${EXAMPLEVIEWJS} POST_BUILD
 # -----------------------------------------------------------------------------
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
-    set_property(TARGET ${EXAMPLEVIEWJS} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
-    set_property(TARGET ${EXAMPLEVIEWJS} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${MV_INSTALL_DIR}/debug/ManiVault Studio.exe","${MV_INSTALL_DIR}/release/ManiVault Studio.exe">)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/ManiVault\ Studio.exe,${MV_INSTALL_DIR}/release/ManiVault\ Studio.exe>)
 endif()

--- a/ExampleViewOpenGL/CMakeLists.txt
+++ b/ExampleViewOpenGL/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 # -----------------------------------------------------------------------------
 # ExampleViewOpenGL Plugin
 # -----------------------------------------------------------------------------
-set(EXAMPLEVIEWGL "ExampleViewOpenGLPlugin")
-PROJECT(${EXAMPLEVIEWGL})
+PROJECT("ExampleViewOpenGLPlugin")
 
 # -----------------------------------------------------------------------------
 # CMake Options
@@ -15,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
 # -----------------------------------------------------------------------------
@@ -39,61 +38,61 @@ find_package(Qt6 COMPONENTS Widgets WebEngineWidgets OpenGL OpenGLWidgets REQUIR
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(EXAMPLEVIEWGL_SOURCES
+set(PLUGIN_SOURCES
     src/ExampleViewGLPlugin.h
     src/ExampleViewGLPlugin.cpp
     src/ExampleViewGLPlugin.json
 )
 
 set(PLUGIN_MOC_HEADERS
-	src/ExampleViewGLPlugin.h
+    src/ExampleViewGLPlugin.h
 )
 
-set(EXAMPLEVIEWGL_WIDGET
+set(PLUGIN_WIDGETS
     src/ExampleGLWidget.h
     src/ExampleGLWidget.cpp
 )
 
-set(EXAMPLEVIEWGL_ACTIONS
+set(PLUGIN_ACTIONS
     src/SettingsAction.h
     src/SettingsAction.cpp
     src/GlobalSettingsAction.h
     src/GlobalSettingsAction.cpp
 )
 
-source_group( Plugin FILES ${EXAMPLEVIEWGL_SOURCES})
-source_group( Widget FILES ${EXAMPLEVIEWGL_WIDGET})
-source_group( Actions FILES ${EXAMPLEVIEWGL_ACTIONS})
+source_group( Plugin FILES ${PLUGIN_SOURCES})
+source_group( Widget FILES ${PLUGIN_WIDGETS})
+source_group( Actions FILES ${PLUGIN_ACTIONS})
 
 # -----------------------------------------------------------------------------
 # CMake Target
 # -----------------------------------------------------------------------------
 # Create dynamic library for the plugin
-add_library(${EXAMPLEVIEWGL} SHARED ${EXAMPLEVIEWGL_SOURCES} ${EXAMPLEVIEWGL_WIDGET} ${EXAMPLEVIEWGL_ACTIONS})
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_SOURCES} ${PLUGIN_WIDGETS} ${PLUGIN_ACTIONS})
 
-qt_wrap_cpp(EXAMPLEVIEWGL_MOC ${PLUGIN_MOC_HEADERS} TARGET ${EXAMPLEVIEWGL})
-target_sources(${EXAMPLEVIEWGL} PRIVATE ${EXAMPLEVIEWGL_MOC})
+qt_wrap_cpp(PLUGIN_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${PLUGIN_MOC})
 
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
 # Include ManiVault headers, including system data plugins
-target_include_directories(${EXAMPLEVIEWGL} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
+target_include_directories(${PROJECT_NAME} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
 # Target properties
 # -----------------------------------------------------------------------------
 # Request C++17
-target_compile_features(${EXAMPLEVIEWGL} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
 # Link to Qt libraries
-target_link_libraries(${EXAMPLEVIEWGL} PRIVATE Qt6::Widgets)
-target_link_libraries(${EXAMPLEVIEWGL} PRIVATE Qt6::WebEngineWidgets)
-target_link_libraries(${EXAMPLEVIEWGL} PRIVATE Qt6::OpenGL)
-target_link_libraries(${EXAMPLEVIEWGL} PRIVATE Qt6::OpenGLWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::WebEngineWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::OpenGL)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::OpenGLWidgets)
 
 # Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
@@ -106,19 +105,19 @@ set(MV_LINK_SUFFIX $<IF:$<CXX_COMPILER_ID:MSVC>,${CMAKE_LINK_LIBRARY_SUFFIX},${C
 set(MV_LINK_LIBRARY "${MV_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}MV_Public${MV_LINK_SUFFIX}")
 set(POINTDATA_LINK_LIBRARY "${PLUGIN_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${MV_LINK_SUFFIX}") 
 
-target_link_libraries(${EXAMPLEVIEWGL} PRIVATE "${MV_LINK_LIBRARY}")
-target_link_libraries(${EXAMPLEVIEWGL} PRIVATE "${POINTDATA_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${MV_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 
 # -----------------------------------------------------------------------------
 # Target installation
 # -----------------------------------------------------------------------------
 # Install the shared plugin libary to the "Plugins" folder in the ManiVault install directory
-install(TARGETS ${EXAMPLEVIEWGL}
+install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
 )
 
-add_custom_command(TARGET ${EXAMPLEVIEWGL} POST_BUILD
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
@@ -130,6 +129,6 @@ add_custom_command(TARGET ${EXAMPLEVIEWGL} POST_BUILD
 # -----------------------------------------------------------------------------
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
-    set_property(TARGET ${EXAMPLEVIEWGL} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
-    set_property(TARGET ${EXAMPLEVIEWGL} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${MV_INSTALL_DIR}/debug/ManiVault Studio.exe","${MV_INSTALL_DIR}/release/ManiVault Studio.exe">)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/ManiVault\ Studio.exe,${MV_INSTALL_DIR}/release/ManiVault\ Studio.exe>)
 endif()

--- a/ExampleWriter/CMakeLists.txt
+++ b/ExampleWriter/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 # -----------------------------------------------------------------------------
 # ExampleWriter Plugin
 # -----------------------------------------------------------------------------
-set(EXAMPLEWRITER "ExampleWriterPlugin")
-PROJECT(${EXAMPLEWRITER})
+PROJECT("ExampleWriterPlugin")
 
 # -----------------------------------------------------------------------------
 # CMake Options
@@ -15,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
 # -----------------------------------------------------------------------------
@@ -39,45 +38,45 @@ find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 # Source files
 # -----------------------------------------------------------------------------
 # Define the plugin sources
-set(EXAMPLEWRITER_SOURCES
+set(PLUGIN_SOURCES
     src/ExampleWriterPlugin.h
     src/ExampleWriterPlugin.cpp
     src/ExampleWriterPlugin.json
 )
 
 set(PLUGIN_MOC_HEADERS
-	src/ExampleWriterPlugin.h
+    src/ExampleWriterPlugin.h
 )
 
-source_group( Plugin FILES ${EXAMPLEWRITER_SOURCES})
+source_group( Plugin FILES ${PLUGIN_SOURCES})
 
 # -----------------------------------------------------------------------------
 # CMake Target
 # -----------------------------------------------------------------------------
 # Create dynamic library for the plugin
-add_library(${EXAMPLEWRITER} SHARED ${EXAMPLEWRITER_SOURCES})
+add_library(${PROJECT_NAME} SHARED ${PLUGIN_SOURCES})
 
-qt_wrap_cpp(EXAMPLERITER_MOC ${PLUGIN_MOC_HEADERS} TARGET ${EXAMPLEWRITER})
-target_sources(${EXAMPLEWRITER} PRIVATE ${EXAMPLERITER_MOC})
+qt_wrap_cpp(PLUGIN_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${PLUGIN_MOC})
 
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
 # Include ManiVault headers, including system data plugins
-target_include_directories(${EXAMPLEWRITER} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
+target_include_directories(${PROJECT_NAME} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION>/include/")
 
 # -----------------------------------------------------------------------------
 # Target properties
 # -----------------------------------------------------------------------------
 # Request C++17
-target_compile_features(${EXAMPLEWRITER} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
 # Link to Qt libraries
-target_link_libraries(${EXAMPLEWRITER} PRIVATE Qt6::Widgets)
-target_link_libraries(${EXAMPLEWRITER} PRIVATE Qt6::WebEngineWidgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::WebEngineWidgets)
 
 # Link to ManiVault and data plugins
 # The link path in this repo assumes that the ManiVault core was built locally
@@ -90,19 +89,19 @@ set(MV_LINK_SUFFIX $<IF:$<CXX_COMPILER_ID:MSVC>,${CMAKE_LINK_LIBRARY_SUFFIX},${C
 set(MV_LINK_LIBRARY "${MV_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}MV_Public${MV_LINK_SUFFIX}")
 set(POINTDATA_LINK_LIBRARY "${PLUGIN_LINK_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${MV_LINK_SUFFIX}") 
 
-target_link_libraries(${EXAMPLEWRITER} PRIVATE "${MV_LINK_LIBRARY}")
-target_link_libraries(${EXAMPLEWRITER} PRIVATE "${POINTDATA_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${MV_LINK_LIBRARY}")
+target_link_libraries(${PROJECT_NAME} PRIVATE "${POINTDATA_LINK_LIBRARY}")
 
 # -----------------------------------------------------------------------------
 # Target installation
 # -----------------------------------------------------------------------------
 # Install the shared plugin libary to the "Plugins" folder in the ManiVault install directory
-install(TARGETS ${EXAMPLEWRITER}
+install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION Plugins COMPONENT PLUGINS # Windows .dll
     LIBRARY DESTINATION Plugins COMPONENT PLUGINS # Linux/Mac .so
 )
 
-add_custom_command(TARGET ${EXAMPLEWRITER} POST_BUILD
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
@@ -114,6 +113,6 @@ add_custom_command(TARGET ${EXAMPLEWRITER} POST_BUILD
 # -----------------------------------------------------------------------------
 # Automatically set the debug environment (command + working directory) for MSVC
 if(MSVC)
-    set_property(TARGET ${EXAMPLEWRITER} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
-    set_property(TARGET ${EXAMPLEWRITER} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,"${MV_INSTALL_DIR}/debug/ManiVault Studio.exe","${MV_INSTALL_DIR}/release/ManiVault Studio.exe">)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug,${MV_INSTALL_DIR}/release>)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_COMMAND $<IF:$<CONFIG:DEBUG>,${MV_INSTALL_DIR}/debug/ManiVault\ Studio.exe,${MV_INSTALL_DIR}/release/ManiVault\ Studio.exe>)
 endif()


### PR DESCRIPTION
- Gets rid of plugin specific variable names so it's easier to copy and adjust
- Fixes start up project
- Fixes differences in whitespace
