### PR TITLE
More robust no vcpkg option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(MV_EXAMPLES_USE_VCPKG OFF)
 if(DEFINED CMAKE_TOOLCHAIN_FILE AND CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg")
     set(MV_EXAMPLES_USE_VCPKG ON)
     set(VCPKG_LIBRARY_LINKAGE "dynamic" CACHE STRING "Link vcpkg libraries dynamically")
@@ -12,9 +11,15 @@ endif()
 set(PROJECT "ExamplePlugins")
 PROJECT(${PROJECT})
 
-# vcpkg is used together with conan on ci
-if(DEFINED VCPKG_TARGET_TRIPLET)
-    set(MV_EXAMPLES_USE_VCPKG ON)
+if(DEFINED MV_EXAMPLES_USE_VCPKG AND NOT MV_EXAMPLES_USE_VCPKG)
+    # vcpkg is used together with conan on ci
+    if(DEFINED VCPKG_TARGET_TRIPLET)
+        set(MV_EXAMPLES_USE_VCPKG ON)
+    else()
+        set(MV_EXAMPLES_USE_VCPKG OFF)
+    endif()
+else()
+    set(MV_EXAMPLES_USE_VCPKG OFF)
 endif()
 
 add_subdirectory(ExampleView)


### PR DESCRIPTION
So far when using the DevBundle and using vcpkg, the `MV_EXAMPLES_USE_VCPKG` option will be ignored.

Now you can toggle `MV_EXAMPLES_USE_VCPKG` while still using vcpkg for other plugins in the some project.