### PR TITLE
Update conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -98,7 +98,7 @@ class ExamplePluginsConan(ConanFile):
         #tc.variables["Qt6_DIR"] = qt_dir
 
         # for Qt < 6.4.2
-        tc.variables["CMAKE_PREFIX_PATH"] = qt_root
+        tc.variables["Qt6_ROOT"] = qt_root
 
         # Use the ManiVault .cmake file to find ManiVault with find_package
         mv_core_root = self.deps_cpp_info["hdps-core"].rootpath


### PR DESCRIPTION
Use `Qt6_ROOT` instead of `CMAKE_PREFIX_PATH` in `conanfile.py`. This is more robust and will also work with newer cmake versions.

Note the change to `Qt6_DIR` when we switch to a newer Qt version, which is already indicated in the `conanfile.py`.